### PR TITLE
add missing pieces of schema.graphql

### DIFF
--- a/amplify/backend/api/appsyncathenaviz/schema.graphql
+++ b/amplify/backend/api/appsyncathenaviz/schema.graphql
@@ -1,3 +1,43 @@
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}
+
+type AthenaQueryResult @aws_cognito_user_pools @aws_iam {
+  QueryExecutionId: ID!
+  file: S3Object
+}
+
+type Mutation {
+  announceQueryResult(input: AnnounceInput!): AthenaQueryResult @aws_iam
+}
+
 type Query {
-  startQuery: ID
+  startQuery(input: QueryInput): AthenaQueryResult
+}
+
+type S3Object @aws_iam {
+  bucket: String!
+  key: String!
+  region: String!
+}
+
+type Subscription {
+  onAnnouncement(QueryExecutionId: ID!): AthenaQueryResult @aws_subscribe(mutations : ["announceQueryResult"])
+}
+
+input AnnounceInput {
+  QueryExecutionId: ID
+  file: S3ObjectInput
+}
+
+input QueryInput {
+  QueryString: String!
+}
+
+input S3ObjectInput {
+  bucket: String!
+  key: String!
+  region: String!
 }


### PR DESCRIPTION
*Description of changes:*
I opened a case with AWS support (Case #: 6541224261) after finding myself unable to run "amplify push" after making any Graphql API changes in this sample project. Alan M. from AWS support determined this was caused by some missing parts of the schema.graphql file and gave me the following workaround to generate the missing code using the AWS CLI.

```
1. Clone the repo 
2. Run the following commands (without the '$'):
   $ cd aws-appsync-visualization-with-athena-app
   $ yarn
3. Modify the bucket configuration in parameters.json as described in the README.
4. Run the following commands to initialise the app and create the stack:
   $ amplify init
   $ amplify push
5. Wait for the stack creation to complete and run the following to open the AppSync API in the web console:
   $ amplify console api
   Choose 'GraphQL'. A browser tab/window should open with the associated API. Go to the "Settings" page of the API and note the "API ID"
6. Change directory to the api configuration folder:
   $ cd amplify/backend/api/appsyncathenaviz
7. Run the following CLI command to get the correct schema.graphql file. Replace <API_ID> with the ID noted in step 5.
   $ aws appsync get-introspection-schema --api-id <API_ID> --format SDL schema.graphql
8. Update the stack:
   $ amplify push
   After this change, you should be able to modify API using the schema.graphql file.
```

This PR replaces the existing schema.graphql file with a schema.graphql generated by the AppSync service/AWS CLI after deploying the base sample project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
