### PR TITLE
Support Multi-Auth with Amplify CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This public dataset provides "population data for a selection of countries, allo
 
 ![architecture](architecture.png)
 
+## Updates
+
+* 11/11/19: Updated to support multi auth with Amplify CLI. Requires Amplify CLI version 3.17 and above.
+
 ## Getting started
 
 For more information about this app and how to get started, please see the [blog post](https://aws.amazon.com/blogs/mobile/visualizing-big-data-with-aws-appsync-amazon-athena-and-aws-amplify/).

--- a/amplify/backend/api/appsyncathenaviz/schema.graphql
+++ b/amplify/backend/api/appsyncathenaviz/schema.graphql
@@ -1,3 +1,31 @@
+input AnnounceInput {
+  QueryExecutionId: ID
+  file: S3ObjectInput
+}
+type AthenaQueryResult @aws_cognito_user_pools @aws_iam {
+  QueryExecutionId: ID!
+  file: S3Object
+}
+type Mutation {
+  announceQueryResult(input: AnnounceInput!): AthenaQueryResult @aws_iam
+}
 type Query {
-  startQuery: ID
+  startQuery(input: QueryInput): AthenaQueryResult
+}
+input QueryInput {
+  QueryString: String!
+}
+type S3Object @aws_iam {
+  bucket: String!
+  region: String!
+  key: String!
+}
+input S3ObjectInput {
+  bucket: String!
+  region: String!
+  key: String!
+}
+type Subscription {
+  onAnnouncement(QueryExecutionId: ID!): AthenaQueryResult
+    @aws_subscribe(mutations: ["announceQueryResult"])
 }

--- a/amplify/backend/api/appsyncathenaviz/stacks/CustomResources.json
+++ b/amplify/backend/api/appsyncathenaviz/stacks/CustomResources.json
@@ -81,29 +81,6 @@
         }
       }
     },
-    "MultiAuthSchema": {
-      "Type": "AWS::AppSync::GraphQLSchema",
-      "Properties": {
-        "ApiId": {
-          "Ref": "AppSyncApiId"
-        },
-        "Definition": {
-          "Fn::Join": [
-            "\n",
-            [
-              "input AnnounceInput { QueryExecutionId: ID file: S3ObjectInput }",
-              "type AthenaQueryResult @aws_cognito_user_pools @aws_iam { QueryExecutionId: ID! file: S3Object }",
-              "type Mutation { announceQueryResult(input: AnnounceInput!): AthenaQueryResult @aws_iam }",
-              "type Query { startQuery(input: QueryInput): AthenaQueryResult } ",
-              "input QueryInput { QueryString: String! }",
-              "type S3Object @aws_iam { bucket: String! region: String! key: String! }",
-              "input S3ObjectInput { bucket: String! region: String! key: String! }",
-              "type Subscription { onAnnouncement(QueryExecutionId: ID!): AthenaQueryResult @aws_subscribe(mutations: [\"announceQueryResult\"]) }"
-            ]
-          ]
-        }
-      }
-    },
     "DataSourceNone": {
       "Type": "AWS::AppSync::DataSource",
       "Properties": {
@@ -117,7 +94,6 @@
     },
     "QueryStartQueryResolver": {
       "Type": "AWS::AppSync::Resolver",
-      "DependsOn": "MultiAuthSchema",
       "Properties": {
         "ApiId": {
           "Ref": "AppSyncApiId"
@@ -147,7 +123,6 @@
     },
     "AnnounceQueryResultResolver": {
       "Type": "AWS::AppSync::Resolver",
-      "DependsOn": "MultiAuthSchema",
       "Properties": {
         "ApiId": {
           "Ref": "AppSyncApiId"
@@ -174,118 +149,6 @@
           ]
         }
       }
-    },
-    "MultiAuthGraphQLAPILambda": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Code": {
-          "ZipFile": {
-            "Fn::Join": [
-              "\n",
-              [
-                "const AWS = require('aws-sdk')",
-                "const response = require('cfn-response')",
-                "const appsync = new AWS.AppSync()",
-                "exports.handler = (event, context, callback) => {",
-                "if (event.RequestType === 'Delete') {",
-                "return response.send(event, context, response.SUCCESS, {})",
-                "}",
-                "const apiId = event.ResourceProperties.AppSyncApiId",
-                "console.log('event -->', JSON.stringify(event, null, 2))",
-                "appsync.getGraphqlApi({ apiId }).promise().then(data => {",
-                "console.log('data -->', JSON.stringify(data, null, 2))",
-                "const { arn, uris, tags, ...req } = data.graphqlApi",
-                "const params = {",
-                "...req,",
-                "additionalAuthenticationProviders: [{ authenticationType: 'AWS_IAM' }]",
-                "}",
-                "console.log('req -->', JSON.stringify(params, null, 2))",
-                "appsync.updateGraphqlApi(params).promise().then(resp => {",
-                "console.log('resp -->', JSON.stringify(resp, null, 2))",
-                "return response.send(event, context, response.SUCCESS)",
-                "}).catch(err => response.send(event, context, response.FAILED, { err }))",
-                "}).catch(err => response.send(event, context, response.FAILED, { err }))",
-                "}"
-              ]
-            ]
-          }
-        },
-        "Handler": "index.handler",
-        "Runtime": "nodejs8.10",
-        "Timeout": "60",
-        "Role": { "Fn::GetAtt": ["MultiAuthGraphQLAPILambdaRole", "Arn"] }
-      },
-      "DependsOn": "MultiAuthGraphQLAPILambdaRole"
-    },
-    "MultiAuthGraphQLAPILambdaRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "RoleName": {
-          "Fn::Join": [
-            "-",
-            [
-              "MultiAuthGraphQLAPILambdaRole",
-              { "Ref": "AppSyncApiId" },
-              { "Ref": "env" }
-            ]
-          ]
-        },
-        "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": {
-                "Service": ["lambda.amazonaws.com"]
-              },
-              "Action": ["sts:AssumeRole"]
-            }
-          ]
-        },
-        "Policies": [
-          {
-            "PolicyName": "update-graphql-api-policy",
-            "PolicyDocument": {
-              "Version": "2012-10-17",
-              "Statement": [
-                {
-                  "Effect": "Allow",
-                  "Action": [
-                    "appsync:GetGraphqlApi",
-                    "appsync:UpdateGraphqlApi"
-                  ],
-                  "Resource": [
-                    {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "arn:aws:appsync:",
-                          { "Ref": "AWS::Region" },
-                          ":",
-                          { "Ref": "AWS::AccountId" },
-                          ":apis/",
-                          { "Ref": "AppSyncApiId" }
-                        ]
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          }
-        ]
-      }
-    },
-    "MultiAuthGraphQLAPI": {
-      "Type": "Custom::MultiAuthGraphQLAPIResource",
-      "Properties": {
-        "ServiceToken": { "Fn::GetAtt": ["MultiAuthGraphQLAPILambda", "Arn"] },
-        "AppSyncApiId": { "Ref": "AppSyncApiId" }
-      },
-      "DependsOn": "MultiAuthGraphQLAPILambda"
     }
   },
   "Conditions": {

--- a/amplify/backend/backend-config.json
+++ b/amplify/backend/backend-config.json
@@ -1,52 +1,64 @@
 {
-    "auth": {
-        "appsyncathenavizb9ef8f65": {
-            "service": "Cognito",
-            "providerPlugin": "awscloudformation",
-            "dependsOn": []
-        }
-    },
-    "api": {
-        "appsyncathenaviz": {
-            "service": "AppSync",
-            "providerPlugin": "awscloudformation",
-            "output": {
-                "securityType": "AMAZON_COGNITO_USER_POOLS"
-            }
-        }
-    },
-    "function": {
-        "S3Trigger20d9f806": {
-            "service": "Lambda",
-            "providerPlugin": "awscloudformation",
-            "build": true,
-            "dependsOn": [
-                {
-                    "category": "api",
-                    "resourceName": "appsyncathenaviz",
-                    "attributes": [
-                        "GraphQLAPIIdOutput",
-                        "GraphQLAPIEndpointOutput"
-                    ]
-                }
-            ]
-        }
-    },
-    "storage": {
-        "sQueryResults": {
-            "service": "S3",
-            "providerPlugin": "awscloudformation",
-            "dependsOn": [
-                {
-                    "category": "function",
-                    "resourceName": "S3Trigger20d9f806",
-                    "attributes": [
-                        "Name",
-                        "Arn",
-                        "LambdaExecutionRole"
-                    ]
-                }
-            ]
-        }
-    }
+	"auth": {
+		"appsyncathenavizb9ef8f65": {
+			"service": "Cognito",
+			"providerPlugin": "awscloudformation",
+			"dependsOn": []
+		}
+	},
+	"api": {
+		"appsyncathenaviz": {
+			"service": "AppSync",
+			"providerPlugin": "awscloudformation",
+			"output": {
+				"authConfig": {
+					"additionalAuthenticationProviders": [
+						{
+							"authenticationType": "AWS_IAM"
+						}
+					],
+					"defaultAuthentication": {
+						"authenticationType": "AMAZON_COGNITO_USER_POOLS",
+						"userPoolConfig": {
+							"userPoolId": "authappsyncathenavizb9ef8f65"
+						}
+					}
+				}
+			}
+		}
+	},
+	"function": {
+		"S3Trigger20d9f806": {
+			"service": "Lambda",
+			"providerPlugin": "awscloudformation",
+			"build": true,
+			"dependsOn": [
+				{
+					"category": "api",
+					"resourceName": "appsyncathenaviz",
+					"attributes": [
+						"GraphQLAPIIdOutput",
+						"GraphQLAPIEndpointOutput"
+					]
+				}
+			]
+		}
+	},
+	"storage": {
+		"sQueryResults": {
+			"service": "S3",
+			"providerPlugin": "awscloudformation",
+			"dependsOn": [
+				{
+					"category": "function",
+					"resourceName": "S3Trigger20d9f806",
+					"attributes": [
+						"Name",
+						"Arn",
+						"LambdaExecutionRole"
+					]
+				}
+			]
+		}
+	}
 }

--- a/amplify/backend/function/S3Trigger20d9f806/src/package-lock.json
+++ b/amplify/backend/function/S3Trigger20d9f806/src/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "S3Trigger20d9f806",
+  "version": "2.0.0",
+  "lockfileVersion": 1
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update implementation with support for multi-auth in AppSync with the Amplify CLI. The API's `schema.graphql` file now tracks the full schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
